### PR TITLE
fix: Make PORT and ROOT_DIR environment variables work correctly

### DIFF
--- a/server.js
+++ b/server.js
@@ -6,7 +6,7 @@ const auth = require('./middleware/auth');
 const apiRoutes = require('./routes/api');
 
 const app = express();
-const PORT = 3000;
+const PORT = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000;
 
 // Middleware
 app.use(auth.basicAuth);

--- a/utils/pathUtil.js
+++ b/utils/pathUtil.js
@@ -1,7 +1,10 @@
 const path = require('path');
 
 // Root directory — everything is sandboxed to where the server was started
-const ROOT_DIR = path.resolve(process.cwd());
+// Can be overridden by ROOT_DIR environment variable
+const ROOT_DIR = process.env.ROOT_DIR 
+    ? path.resolve(process.env.ROOT_DIR) 
+    : path.resolve(process.cwd());
 
 // Path Sandboxing Helper
 function sandboxPath(requestedPath) {


### PR DESCRIPTION
## 🐛 Bug Fix

### Problem
Environment variables PORT and ROOT_DIR were not being read from the environment, causing the server to always use hardcoded values.

### Root Causes

1. **PORT (server.js)**: Hardcoded as `const PORT = 3000;`
2. **ROOT_DIR (utils/pathUtil.js)**: Always used `process.cwd()`, ignoring `ROOT_DIR` env var

### Solution

**server.js**:
```javascript
// Before
const PORT = 3000;

// After
const PORT = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000;
```

**utils/pathUtil.js**:
```javascript
// Before
const ROOT_DIR = path.resolve(process.cwd());

// After
const ROOT_DIR = process.env.ROOT_DIR 
    ? path.resolve(process.env.ROOT_DIR) 
    : path.resolve(process.cwd());
```

### Testing
```bash
# Test custom PORT
PORT=8080 npm start

# Test custom ROOT_DIR
ROOT_DIR=/var/www npm start

# Test both
PORT=8080 ROOT_DIR=/var/www npm start
```

Fixes #4