### PR TITLE
fix: Support PORT and ROOT_DIR environment variables

### DIFF
--- a/server.js
+++ b/server.js
@@ -6,7 +6,7 @@ const auth = require('./middleware/auth');
 const apiRoutes = require('./routes/api');
 
 const app = express();
-const PORT = 3000;
+const PORT = process.env.PORT || 3000;
 
 // Middleware
 app.use(auth.basicAuth);

--- a/utils/pathUtil.js
+++ b/utils/pathUtil.js
@@ -1,7 +1,7 @@
 const path = require('path');
 
-// Root directory — everything is sandboxed to where the server was started
-const ROOT_DIR = path.resolve(process.cwd());
+// Root directory from environment variable or current working directory
+const ROOT_DIR = process.env.ROOT_DIR ? path.resolve(process.env.ROOT_DIR) : path.resolve(process.cwd());
 
 // Path Sandboxing Helper
 function sandboxPath(requestedPath) {


### PR DESCRIPTION
## 🐛 Bug Fix

### Problem
The server ignores `PORT` and `ROOT_DIR` environment variables:
- PORT is hardcoded to 3000
- ROOT_DIR always defaults to process.cwd()

This makes it impossible to:
- Run multiple instances on different ports
- Serve files from a specific directory

### Solution
Read configuration from environment variables with sensible defaults:
- `PORT`: defaults to 3000
- `ROOT_DIR`: defaults to process.cwd()

### Changes
- **server.js**: Read PORT from `process.env.PORT`
- **utils/pathUtil.js**: Read ROOT_DIR from `process.env.ROOT_DIR`

### Usage
```bash
# Custom port
PORT=8080 npm start

# Custom root directory
ROOT_DIR=/data/files npm start

# Both
PORT=8080 ROOT_DIR=/data npm start
```

### Testing
- ✅ Default behavior unchanged (backward compatible)
- ✅ PORT environment variable works
- ✅ ROOT_DIR environment variable works

Fixes #4